### PR TITLE
Changes Made to Fix Breadcrumb Clickability:

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -245,8 +245,6 @@ body {
     margin-right: auto;
     padding-left: 1rem;
     padding-right: 1rem;
-    pointer-events: auto;
-    position: relative;
   }
 
   @media (min-width: 640px) {
@@ -317,6 +315,41 @@ body {
     clip: auto;
     white-space: normal;
   }
+}
+
+/* ============================================================================
+   CUSTOM SCROLLBAR STYLES
+   ============================================================================ */
+/* Webkit browsers (Chrome, Safari, Edge) */
+::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+::-webkit-scrollbar-track {
+  background: #1a1a1a;
+  border-radius: 6px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #4d4d4d;
+  border-radius: 6px;
+  border: 2px solid #1a1a1a;
+  transition: background 0.3s ease;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #FD5A1E;
+}
+
+::-webkit-scrollbar-thumb:active {
+  background: #e54e17;
+}
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #4d4d4d #1a1a1a;
 }
 
 /* ============================================================================

--- a/app/vending-machines/[id]/page.tsx
+++ b/app/vending-machines/[id]/page.tsx
@@ -74,12 +74,12 @@ const MachineDetailPage = () => {
   return (
     <div className="min-h-screen bg-[#000000]">
       {/* Breadcrumb Navigation */}
-      <div className="pt-10 md:pt-16">
+      <div className="pt-20 relative z-40">
         <Breadcrumbs items={breadcrumbItems} />
       </div>
 
       {/* Hero Section */}
-      <section className="bg-gradient-to-b from-[#000000] to-[#111111] py-8 sm:py-12">
+      <section className="bg-gradient-to-b from-[#000000] to-[#111111] py-8 sm:py-12 relative z-10">
         <div className="container-custom">
           <div className="text-center mb-6 sm:mb-8 px-4">
             <motion.p

--- a/app/vending-machines/page.tsx
+++ b/app/vending-machines/page.tsx
@@ -88,7 +88,7 @@ const VendingMachinesPage = () => {
   return (
     <div className="min-h-screen bg-[#000000]">
       {/* Breadcrumb Navigation */}
-      <div className="pt-16 md:pt-20">
+      <div className="pt-20 relative z-40">
         <Breadcrumbs items={breadcrumbItems} />
       </div>
 
@@ -157,7 +157,7 @@ const VendingMachinesPage = () => {
       />
 
       {/* SEO-Enhanced Hero Header Section */}
-      <section className="pt-12 sm:pt-16 pb-8 bg-gradient-to-b from-[#000000] via-[#111111] to-[#000000]">
+      <section className="pt-12 sm:pt-16 pb-8 bg-gradient-to-b from-[#000000] via-[#111111] to-[#000000] relative z-10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -202,7 +202,7 @@ const VendingMachinesPage = () => {
       {/* Filter Section */}
       <section className="pt-6 sm:pt-8 bg-[#000000] relative z-20">
         <div className="container mx-auto px-4 max-w-7xl">
-          <div className="flex flex-wrap gap-3 sm:gap-4 justify-center mb-8 sm:mb-12 relative z-30">
+          <div className="flex flex-wrap gap-3 sm:gap-4 justify-center mb-8 sm:mb-12 relative z-20">
             {filterOptions.map((option) => (
               <button
                 key={option.id}
@@ -244,8 +244,7 @@ const VendingMachinesPage = () => {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3 }}
-              className="space-y-8 relative z-30"
-              style={{ pointerEvents: 'auto' }}
+              className="space-y-8 relative z-20"
             >
               {machines.map((machine, index) => (
                 <MachineCard key={machine.id} machine={machine} index={index} />

--- a/components/ExitIntentPopup.tsx
+++ b/components/ExitIntentPopup.tsx
@@ -250,7 +250,7 @@ export function ExitIntentPopup({ delay = 5000 }: ExitIntentPopupProps) {
                     Wait! Don&apos;t Miss Out...
                   </h2>
                   <p className="text-sm md:text-base text-[#FD5A1E] font-semibold">
-                    Get a FREE Vending Machine!
+                    Get a FREE Premium Vending Machine – See If You Qualify!
                   </p>
                 </div>
 
@@ -315,6 +315,13 @@ export function ExitIntentPopup({ delay = 5000 }: ExitIntentPopupProps) {
                     <CheckCircle className="h-4 w-4 text-[#FD5A1E] flex-shrink-0 mt-0.5" />
                     <span className="text-[#F5F5F5] text-xs">Zero upfront costs</span>
                   </div>
+                </div>
+
+                {/* Qualifier Text */}
+                <div className="mb-3 p-2 bg-[#4d4d4d]/20 rounded-lg border border-[#FD5A1E]/20">
+                  <p className="text-[10px] md:text-xs text-[#A5ACAF] text-center leading-relaxed">
+                    *Available for locations with adequate employee count or customer traffic to ensure service profitability
+                  </p>
                 </div>
 
                 {/* Quick Lead Capture Form */}

--- a/components/landing/WorkplaceTransformSection.tsx
+++ b/components/landing/WorkplaceTransformSection.tsx
@@ -417,6 +417,7 @@ const WorkplaceTransformSection: React.FC<WorkplaceTransformSectionProps> = ({
               loading="lazy" // Explicit lazy loading
               quality={90}
               className="object-cover transition-transform duration-500 rounded-xl hover:scale-105"
+              style={{ height: 'auto' }}
             />
 
             {/* Gradient overlay */}

--- a/components/layout/ResizableNavbar.tsx
+++ b/components/layout/ResizableNavbar.tsx
@@ -82,7 +82,8 @@ const ResizableNavbar = () => {
                   alt="AMP Vending Logo"
                   width={120}
                   height={73}
-                  className={`h-auto object-contain transition-all duration-300 ${
+                  style={{ height: "auto" }}
+                  className={`object-contain transition-all duration-300 ${
                     isScrolled ? 'w-[80px] sm:w-[90px]' : 'w-[100px] sm:w-[120px]'
                   }`}
                   priority

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -14,17 +14,17 @@ interface BreadcrumbsProps {
 export function Breadcrumbs({ items, className = '' }: BreadcrumbsProps) {
   return (
     <nav
-      className={`bg-[#000000]/80 backdrop-blur-sm border-b border-[#333333] ${className}`}
+      className={`bg-[#000000]/80 backdrop-blur-sm border-b border-[#333333] relative z-40 ${className}`}
       aria-label="Breadcrumb"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 sm:py-4">
-        <ol className="flex items-center flex-wrap gap-2 text-sm">
+        <ol className="flex items-center flex-wrap gap-2 text-sm relative z-40">
           {items.map((item, index) => {
             const isLast = index === items.length - 1;
             const isFirst = index === 0;
 
             return (
-              <li key={index} className="flex items-center gap-2">
+              <li key={index} className="flex items-center gap-2 relative z-40">
                 {index > 0 && (
                   <ChevronRight
                     className="w-4 h-4 text-[#4d4d4d]"
@@ -42,7 +42,7 @@ export function Breadcrumbs({ items, className = '' }: BreadcrumbsProps) {
                 ) : item.href ? (
                   <Link
                     href={item.href}
-                    className="text-[#A5ACAF] hover:text-[#FD5A1E] transition-colors focus:outline-none focus:text-[#FD5A1E] flex items-center gap-1.5"
+                    className="text-[#A5ACAF] hover:text-[#FD5A1E] transition-colors focus:outline-none focus:text-[#FD5A1E] flex items-center gap-1.5 relative z-40 cursor-pointer"
                   >
                     {isFirst && (
                       <Home className="w-4 h-4" aria-hidden="true" />

--- a/next.config.js
+++ b/next.config.js
@@ -51,7 +51,7 @@ const nextConfig = {
   // Note: In Next.js 16, quality is set per-image via the Image component
   // Default quality is 75 (down from 90 in older versions) for better performance
   images: {
-    qualities: [60,75],
+    qualities: [60, 75, 90],
     deviceSizes: [640, 750, 828, 1080, 1200],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
     formats: ["image/webp"],


### PR DESCRIPTION
1. Updated Breadcrumbs Component (Breadcrumbs.tsx) Added proper z-index stacking and pointer-events:
nav: Added relative z-40
ol: Added relative z-40
li: Added relative z-40
Link elements: Added relative z-40 cursor-pointer
2. Fixed .container-custom CSS (globals.css:240-281) Removed problematic properties:
❌ Removed pointer-events: auto (was blocking interactions) ❌ Removed position: relative (was causing stacking issues) ✅ Kept responsive padding and max-width
3. Updated Page Layouts Both vending machines pages now have proper z-index hierarchy: Listing Page (page.tsx): Breadcrumb wrapper: z-40
Hero section: z-10
Filter section: z-20
Machine cards: z-20
Detail Page (page.tsx):
Breadcrumb wrapper: z-40
Hero section: z-10
4. Fixed Syntax Error Removed duplicate > character that was causing parsing error

Fixed! The issue was in ResizableNavbar.tsx:80-89. The Problem: The Image component had width={120} and height={73} defined But the className was modifying the width with CSS (w-[80px], w-[100px]) Next.js requires you to explicitly set the other dimension to "auto" in the style prop when one dimension is modified The Fix:
Added style={{ height: "auto" }} to explicitly maintain aspect ratio This tells Next.js to automatically calculate the height based on the CSS-modified width