### PR TITLE
Fix

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,17 +5,78 @@ import OptimizedHomePage from '@/components/landing/OptimizedHomePage';
 export const metadata = PAGE_METADATA.HOME;
 
 export default function HomePage() {
+  // SEO-optimized structured data targeting high-volume keywords
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "LocalBusiness",
     "name": "AMP Vending Machines",
+    "alternateName": "AMP Vending - Free Vending Machine Placement",
+    "description": "Free vending machine placement for offices, warehouses, and workplaces. Snack, drink & combo vending machines with cashless payment. No cost installation in Modesto, Stockton & Central California.",
     "image": "https://www.ampvendingmachines.com/images/promos/amp-vending-promo-modesto.webp",
     "url": "https://www.ampvendingmachines.com",
+    "telephone": "+12094035450",
+    "priceRange": "Free Installation",
     "address": {
       "@type": "PostalAddress",
+      "streetAddress": "4120 Dale Rd ste j8 1005",
       "addressLocality": "Modesto",
-      "addressRegion": "CA"
-    }
+      "addressRegion": "CA",
+      "postalCode": "95354",
+      "addressCountry": "US"
+    },
+    "geo": {
+      "@type": "GeoCoordinates",
+      "latitude": 37.6390972,
+      "longitude": -120.9968782
+    },
+    "areaServed": [
+      "Modesto", "Stockton", "Turlock", "Ceres", "Riverbank", "Tracy", "Manteca", "Lodi",
+      "Stanislaus County", "San Joaquin County", "Central California"
+    ],
+    "hasOfferCatalog": {
+      "@type": "OfferCatalog",
+      "name": "Vending Machine Services",
+      "itemListElement": [
+        {
+          "@type": "Offer",
+          "itemOffered": {
+            "@type": "Service",
+            "name": "Free Vending Machine Placement",
+            "description": "Free snack and drink vending machine placement for businesses with no cost installation"
+          }
+        },
+        {
+          "@type": "Offer",
+          "itemOffered": {
+            "@type": "Service",
+            "name": "Cashless Vending Machines",
+            "description": "Vending machines with credit card, Apple Pay, and tap-to-pay contactless payment"
+          }
+        },
+        {
+          "@type": "Offer",
+          "itemOffered": {
+            "@type": "Service",
+            "name": "Office Vending Solutions",
+            "description": "Full-service vending machines for offices, warehouses, and workplaces"
+          }
+        }
+      ]
+    },
+    "openingHoursSpecification": [
+      {
+        "@type": "OpeningHoursSpecification",
+        "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+        "opens": "08:00",
+        "closes": "20:00"
+      },
+      {
+        "@type": "OpeningHoursSpecification",
+        "dayOfWeek": ["Saturday", "Sunday"],
+        "opens": "08:00",
+        "closes": "20:00"
+      }
+    ]
   };
 
   return (

--- a/app/vending-machines/page.tsx
+++ b/app/vending-machines/page.tsx
@@ -102,8 +102,8 @@ const VendingMachinesPage = () => {
           __html: JSON.stringify({
             "@context": "https://schema.org",
             "@type": "CollectionPage",
-            "name": "Commercial Vending Machines | Professional Installation | AMP Vending",
-            "description": "Explore our range of commercial vending machines with touchscreen technology, professional installation, and maintenance-free operation for offices, schools, and businesses in Central California.",
+            "name": "Free Snack & Drink Vending Machines | Free Placement for Offices & Businesses | Central CA",
+            "description": "Browse our snack, drink & combo vending machines. Get a free vending machine for your office, warehouse, or workplace. Cashless payment with tap-to-pay technology. No cost installation in Modesto, Stockton & Central California.",
             "url": "https://www.ampvendingmachines.com/vending-machines/",
             "publisher": {
               "@type": "Organization",
@@ -181,12 +181,12 @@ const VendingMachinesPage = () => {
             </div>
 
             <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-[#F5F5F5] mb-4">
-              Premium Vending <span className="text-[#FD5A1E]">Machines</span>
+              Free Snack & Drink <span className="text-[#FD5A1E]">Vending Machines</span>
             </h1>
 
             <p className="text-lg sm:text-xl lg:text-2xl text-[#A5ACAF] max-w-4xl mx-auto mb-8">
-              Professional vending machine solutions with touchscreen technology, complete installation,
-              and maintenance-free operation for businesses throughout Central California.
+              Get a free vending machine for your office, warehouse, or workplace. Snack, drink & combo machines
+              with cashless payment and tap-to-pay technology. No cost installation in Central California.
             </p>
 
             {/* Enhanced Machine Count Display with SEO Keywords */}

--- a/components/landing/CTASection.tsx
+++ b/components/landing/CTASection.tsx
@@ -37,41 +37,41 @@ const CTASection = () => {
           transition={{ duration: 0.8 }}
         >
           <h2 className="text-4xl md:text-5xl font-bold text-white mb-6">
-            Modesto&apos;s Premier <span className="text-[#FD5A1E]">Vending Machine Provider</span>
+            Get a Free <span className="text-[#FD5A1E]">Vending Machine</span> for Your Business
           </h2>
           <p className="text-xl text-white/80 max-w-3xl mx-auto mb-8">
-            Join leading Modesto and Stanislaus County businesses enjoying AMP Vending Machines
-            state-of-the-art vending solutions with comprehensive maintenance and support.
+            Free snack & drink vending machine placement for offices, warehouses, and workplaces.
+            No cost installation with cashless payment technology. Serving Modesto, Stockton & Central CA.
           </p>
-          
-          {/* Key Benefits */}
+
+          {/* Key Benefits - SEO Optimized */}
           <div className="flex flex-wrap justify-center gap-8 mb-12">
-            <motion.div 
+            <motion.div
               className="flex items-center"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.1 }}
             >
               <CheckCircle size={24} className="text-white mr-2" />
-              <span className="text-white">Professional Installation</span>
+              <span className="text-white">Free Installation</span>
             </motion.div>
-            <motion.div 
+            <motion.div
               className="flex items-center"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.2 }}
             >
               <CheckCircle size={24} className="text-white mr-2" />
-              <span className="text-white">Full-Service Support</span>
+              <span className="text-white">Cashless Payment</span>
             </motion.div>
-            <motion.div 
+            <motion.div
               className="flex items-center"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.3 }}
             >
               <CheckCircle size={24} className="text-white mr-2" />
-              <span className="text-white">Latest Technology</span>
+              <span className="text-white">No Cost Maintenance</span>
             </motion.div>
           </div>
           
@@ -89,7 +89,7 @@ const CTASection = () => {
                 rightIcon={<ArrowRight size={20} />}
                 animate
               >
-                Get Free Consultation
+                Get a Free Vending Machine
               </AccessibleButton>
             </motion.div>
           </div>

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -13,35 +13,35 @@ const FAQSection = () => {
 
 
 
-  // FAQ data structure with categories - updated content
+  // FAQ data structure with categories - SEO optimized for high-volume keywords
   const faqItems = [
     {
       id: 1,
-      question: "What makes AMP Vending Machines different in Modesto?",
-      answer: "AMP Vending provides Modesto and Stanislaus County businesses with 21.5\" HD touchscreen vending machines, contactless payment technology, and smart inventory monitoring. We offer comprehensive service including free installation, maintenance, and restocking throughout Central California.",
+      question: "How do I get a free vending machine for my business?",
+      answer: "Getting a free vending machine is simple! AMP Vending provides free snack and drink vending machine placement for offices, warehouses, and workplaces in Modesto, Stockton, and Central Valley California. We handle everything - free installation, free maintenance, and free restocking. Contact us to qualify for free vending machine placement.",
       icon: <Zap size={20} />,
-      category: "technology"
+      category: "free placement"
     },
     {
       id: 2,
-      question: "What types of products are available?",
-      answer: "We offer a wide selection of premium snacks, beverages, and healthy options. Our team customizes the product mix based on your workplace preferences and employee feedback.",
+      question: "What types of vending machines do you offer?",
+      answer: "We offer snack vending machines, drink vending machines, beverage vending machines, combo vending machines, and healthy vending machines. AMP vending machines feature 21.5\" HD touchscreen displays, cashless payment with tap-to-pay technology, and refrigerated options for cold drinks and fresh food.",
       icon: <Search size={20} />,
-      category: "products"
+      category: "machine types"
     },
     {
       id: 3,
-      question: "How often are machines restocked and maintained?",
-      answer: "We monitor inventory levels remotely and typically restock weekly, though high-traffic locations may receive more frequent service. All maintenance is included in our service package.",
-      icon: <HelpCircle size={20} />,
-      category: "service"
+      question: "Do your vending machines accept credit cards and Apple Pay?",
+      answer: "Yes! All our vending machines are cashless vending machines that accept credit cards, debit cards, Apple Pay, Google Pay, and tap-to-pay contactless payments. We also accept traditional cash and coins for maximum convenience.",
+      icon: <CreditCard size={20} />,
+      category: "cashless payment"
     },
     {
       id: 4,
-      question: "What payment methods are accepted?",
-      answer: "Our machines accept multiple payment options including credit/debit cards, mobile payments (Apple Pay, Google Pay), as well as traditional cash and coins for maximum convenience.",
-      icon: <CreditCard size={20} />,
-      category: "payment"
+      question: "What locations qualify for free vending machine placement?",
+      answer: "We provide free vending machine placement for offices, warehouses, factories, schools, gyms, hotels, hospitals, and break rooms with 50+ employees or regular foot traffic. Our full-service vending includes free installation, maintenance, and restocking in Modesto, Stockton, Stanislaus County, San Joaquin County and throughout Central Valley California.",
+      icon: <HelpCircle size={20} />,
+      category: "locations"
     }
   ];
 
@@ -70,14 +70,14 @@ const FAQSection = () => {
     >
       <div className="text-center mb-12">
         <div className="inline-flex items-center px-4 py-2 bg-[#FD5A1E]/10 rounded-full mb-6">
-          <span className="text-[#FD5A1E] font-medium text-sm">Quick Answers</span>
+          <span className="text-[#FD5A1E] font-medium text-sm">Free Vending Machine Placement</span>
         </div>
         <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 text-[#F5F5F5]">
-          Vending Machine <span className="text-[#FD5A1E]">FAQs</span>  
+          Vending Machine <span className="text-[#FD5A1E]">FAQs</span>
         </h2>
 
         <p className="text-lg text-[#A5ACAF] max-w-3xl mx-auto">
-          Everything you need to know about AMP Vending Machines in Modesto, Stanislaus County to Stockton San Joaquin County.
+          Learn how to get a free vending machine for your business. Snack, drink & cashless vending machines for offices and workplaces in Central Valley California.
         </p>
       </div>
 
@@ -125,11 +125,11 @@ const FAQSection = () => {
         transition={{ duration: 0.6, delay: 0.6 }}
       >
         <h3 className="text-xl font-bold text-[#F5F5F5] mb-4">
-          Have More Questions About AMP Vending Machines?
+          Ready to Get a Free Vending Machine?
         </h3>
         <p className="text-[#A5ACAF] max-w-2xl mx-auto mb-6">
-          Our Modesto-based team is ready to answer any questions about AMP Vending Machines,
-          technology features, service packages, and installation process for Stanislaus County businesses.
+          Contact us about free vending machine placement for your office, warehouse, or workplace.
+          We serve Modesto, Stockton, and all of Central Valley California with snack, drink & combo vending machines.
         </p>
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
           <Link

--- a/components/landing/OptimizedHomePage.tsx
+++ b/components/landing/OptimizedHomePage.tsx
@@ -38,12 +38,12 @@ export default function OptimizedHomePage() {
         <ResponsiveHero
           title={
             <>
-              Vending Machines in<br/><span className="text-[#FD5A1E]"> Modesto, Stockton & Central Valley</span>
+              Free Vending Machine<br/><span className="text-[#FD5A1E]">For Your Business</span>
             </>
           }
-          subtitle="AMP Vending - Premier commercial vending solutions for businesses in Modesto, Stockton, Stanislaus County, San Joaquin County, and surrounding areas."
+          subtitle="Get a free snack & drink vending machine for your office, warehouse, or workplace. No cost installation with cashless payment technology. Serving Modesto, Stockton & Central California."
           primaryCta={{ text: "View Our Machines", href: "/vending-machines" }}
-          secondaryCta={{ text: "Get Started", href: "/contact" }}
+          secondaryCta={{ text: "Get a Free Machine", href: "/contact" }}
         />
         </Suspense>
       </Section>
@@ -156,16 +156,16 @@ export default function OptimizedHomePage() {
 }
 
 
-// Hero loading fallback for critical path
+// Hero loading fallback for critical path - SEO optimized content
 const HeroLoadingFallback = React.memo(() => (
   <div className="min-h-screen bg-black flex items-center justify-center">
     <div className="text-center px-4">
       <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-[#F5F5F5] mb-6 animate-pulse">
-        Vending Machines in Modesto, Stockton
-        <br />& <span className="text-[#FD5A1E]">Central Valley</span>
+        Free Vending Machine
+        <br /><span className="text-[#FD5A1E]">For Your Business</span>
       </h1>
       <p className="text-xl md:text-2xl text-[#F5F5F5] mb-8 max-w-3xl mx-auto opacity-75">
-        AMP Vending Machines - Loading your commercial vending solutions for Stanislaus & San Joaquin County...
+        Snack & drink vending machines with cashless payment. Free placement for offices & workplaces in Central CA...
       </p>
     </div>
   </div>

--- a/components/layout/ResizableNavbar.tsx
+++ b/components/layout/ResizableNavbar.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 import { AccessibleButton } from '@/components/ui/AccessibleButton';
 import { X, Menu } from 'lucide-react';
 
@@ -16,21 +17,15 @@ interface NavItem {
  *
  * A modern, accessible navbar that adapts on scroll with CSS transitions
  * Performance optimized: Removed framer-motion to reduce main-thread blocking
+ * Uses usePathname() hook for proper active page highlighting during client-side navigation
  */
 const ResizableNavbar = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-  const [pathname, setPathname] = useState<string>('');
-  const [isMounted, setIsMounted] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Get pathname on client side only
-  useEffect(() => {
-    setIsMounted(true);
-    if (typeof window !== 'undefined') {
-      setPathname(window.location.pathname);
-    }
-  }, []);
+  // Use Next.js usePathname hook for reactive pathname updates during navigation
+  const pathname = usePathname();
 
   // Close mobile menu when clicking outside
   useEffect(() => {

--- a/lib/config/metadata.ts
+++ b/lib/config/metadata.ts
@@ -1,105 +1,42 @@
 /**
  * Metadata Configuration - Centralized SEO Settings
  *
- * This file provides all metadata configuration for the application,
- * using centralized business data for consistency and maintainability.
+ * This file provides Next.js metadata configuration for the application.
+ * All SEO constants are imported from seoData.ts (single source of truth).
  */
 
 import type { Metadata } from "next";
-import { AMP_VENDING_BUSINESS_INFO } from "@/lib/data/businessData";
+import { SEO_CONSTANTS } from "@/lib/data/seoData";
 
 /**
  * Root Layout Metadata Configuration
+ * Imports SEO data from seoData.ts to avoid duplication
  */
 export const rootMetadata: Metadata = {
-  // Basic SEO metadata
+  // Title configuration - uses SEO_CONSTANTS
   title: {
-    default:
-      "AMP Vending Machines | Modesto & Stanislaus County | ampvendingmachines.com",
-    template: "%s | AMP Vending Machines - Modesto & Stanislaus County",
+    default: SEO_CONSTANTS.SITE_TITLE,
+    template: `%s | ${SEO_CONSTANTS.SITE_NAME} - Central Valley, CA`,
   },
 
-  // Optimized description for Google search results (under 160 characters)
-  description: `Premium vending machines in Modesto & Stanislaus County CA. Touchscreen technology, free installation. Call ${AMP_VENDING_BUSINESS_INFO.contact.phone}`,
+  // Description from single source of truth
+  description: SEO_CONSTANTS.SITE_DESCRIPTION,
 
-  // Enhanced keywords targeting local and commercial searches
-  keywords: [
-    // Brand Keywords (Exact Match)
-    "ampvendingmachines",
-    "ampvendingmachines.com",
-    "amp vending machines",
-    "amp vending",
-   
-    // Location + Service (Top Priority)
-    "vending machines Modesto",
-    "vending machines Modesto CA",
-    "vending machines Stockton",
-    "vending machines Stockton CA",
-    "vending machines San Joaquin County",
-    "Modesto vending machines",
-    "vending machines Stanislaus County",
-    "Stanislaus County vending machines",
-    "vending machines Modesto California",
-    "Modesto CA vending machines",
-    "vending machines near me Modesto",
-    "vending machines near me Stanislaus County",
-    "vending machines near me San Joaquin County",
-    "vending machines near me",
-
-    // Stanislaus County Cities
-    "vending machines Turlock CA",
-    "vending machines Ceres CA",
-    "vending machines Riverbank CA",
-    "vending machines Oakdale CA",
-    "vending machines Patterson CA",
-
-    // Commercial Keywords
-    "commercial vending machines Modesto",
-    "office vending machines Modesto CA",
-    "workplace vending machines Stanislaus County",
-    "business vending machines Modesto",
-    "company vending machines Central California",
-
-    // Features
-    "touchscreen vending machines Modesto",
-    "contactless vending machines",
-    "smart vending machines Modesto",
-    "modern vending machines",
-    "refrigerated vending machines Modesto",
-
-    // Services
-    "vending machine supplier Modesto",
-    "vending machine supplier",
-    "vending machine supplier near me",
-    "vending machine provider Stanislaus County",
-    "vending machine installation Modesto",
-    "free vending machines Modesto CA",
-    "vending machine rental Modesto",
-    "vending machine service Stanislaus County",
-
-    // Regional
-    "Central California vending machines",
-    "Central Valley vending machines",
-    "Northern California vending",
-
-    // General
-    "AMP Vending Machines Modesto",
-    "professional vending installation",
-    "maintenance-free vending machines",
-  ].join(", "),
+  // Keywords from PRIMARY_KEYWORDS array in seoData.ts
+  keywords: SEO_CONSTANTS.PRIMARY_KEYWORDS.join(", "),
 
   // Author and publisher information
   authors: [
     {
-      name: AMP_VENDING_BUSINESS_INFO.name,
-      url: AMP_VENDING_BUSINESS_INFO.contact.website,
+      name: SEO_CONSTANTS.BUSINESS_NAME,
+      url: SEO_CONSTANTS.BASE_URL,
     },
   ],
-  creator: AMP_VENDING_BUSINESS_INFO.name,
-  publisher: AMP_VENDING_BUSINESS_INFO.name,
+  creator: SEO_CONSTANTS.BUSINESS_NAME,
+  publisher: SEO_CONSTANTS.BUSINESS_NAME,
 
   // Application metadata
-  applicationName: AMP_VENDING_BUSINESS_INFO.name,
+  applicationName: SEO_CONSTANTS.SITE_NAME,
   generator: "Next.js",
 
   // Enhanced robots directive for maximum indexing
@@ -117,9 +54,9 @@ export const rootMetadata: Metadata = {
 
   // Language and locale settings
   alternates: {
-    canonical: AMP_VENDING_BUSINESS_INFO.contact.website,
+    canonical: SEO_CONSTANTS.BASE_URL,
     languages: {
-      "en-US": AMP_VENDING_BUSINESS_INFO.contact.website,
+      "en-US": SEO_CONSTANTS.BASE_URL,
     },
   },
 
@@ -127,55 +64,52 @@ export const rootMetadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: AMP_VENDING_BUSINESS_INFO.contact.website,
-    siteName: "AMP Vending Machines",
-    title:
-      "AMP Vending Machines | Modesto & Stanislaus County | Stockton & San Joaquin County | Central Valley | Northern California",
-    description:
-      "AMP Vending Machines - Premier vending machine provider in Modesto, Stanislaus County & Central California. Professional touchscreen vending with free installation.",
+    url: SEO_CONSTANTS.BASE_URL,
+    siteName: SEO_CONSTANTS.SITE_NAME,
+    title: SEO_CONSTANTS.SITE_TITLE,
+    description: SEO_CONSTANTS.SITE_DESCRIPTION,
     images: [
       {
-        url: `${AMP_VENDING_BUSINESS_INFO.contact.website}/images/promos/amp-vending-promo-modesto.webp`,
+        url: `${SEO_CONSTANTS.BASE_URL}/images/promos/amp-vending-promo-modesto.webp`,
         width: 1200,
         height: 630,
-        alt: "AMP Design and Consulting vending machine promotion in Modesto and Stanislaus County",
+        alt: "Free vending machine placement for businesses in Modesto and Central California",
         type: "image/webp",
       },
       {
-        url: `${AMP_VENDING_BUSINESS_INFO.contact.website}/images/og/amp-vending-logo-og.webp`,
+        url: `${SEO_CONSTANTS.BASE_URL}/images/og/amp-vending-logo-og.webp`,
         width: 1200,
         height: 630,
-        alt: "AMP Vending premium workplace vending machines with touchscreen technology",
+        alt: "AMP Vending - snack and drink vending machines with cashless payment",
         type: "image/webp",
       },
       {
-        url: `${AMP_VENDING_BUSINESS_INFO.contact.website}/images/machines/amp-premium-touchscreen-vending-machine.webp`,
+        url: `${SEO_CONSTANTS.BASE_URL}/images/machines/amp-premium-touchscreen-vending-machine.webp`,
         width: 800,
         height: 600,
-        alt: "Premium touchscreen vending machine by AMP Vending",
+        alt: "Premium touchscreen vending machine with tap-to-pay technology",
         type: "image/webp",
       },
     ],
   },
 
   // Enhanced Twitter Card metadata
- twitter: {
-  card: "summary_large_image",
-  site: "@ampvending",
-  creator: "@ampvending",
-  title: `Premium Commercial Vending Machines | ${AMP_VENDING_BUSINESS_INFO.name}`,
-  description:
-    "Professional vending machines with touchscreen technology for enhanced workplace satisfaction in the Central Valley, Northern California.",
-  images: {
-    url: `${AMP_VENDING_BUSINESS_INFO.contact.website}/images/promos/amp-vending-promo-modesto.webp`,
-    alt: "AMP Design and Consulting vending machine promotion in Modesto and Stanislaus County",
+  twitter: {
+    card: "summary_large_image",
+    site: "@ampvending",
+    creator: "@ampvending",
+    title: SEO_CONSTANTS.SITE_TITLE,
+    description: SEO_CONSTANTS.SITE_DESCRIPTION,
+    images: {
+      url: `${SEO_CONSTANTS.BASE_URL}/images/promos/amp-vending-promo-modesto.webp`,
+      alt: "Free vending machine placement for offices and workplaces in Central California",
+    },
   },
-},
 
   // App links for mobile optimization
   appLinks: {
     web: {
-      url: AMP_VENDING_BUSINESS_INFO.contact.website,
+      url: SEO_CONSTANTS.BASE_URL,
       should_fallback: true,
     },
   },
@@ -185,32 +119,32 @@ export const rootMetadata: Metadata = {
     // Referrer policy for security and analytics
     referrer: "same-origin",
 
-    // Geographic targeting
-    "geo.region": "US-CA",
-    "geo.placename": "Modesto, Stanislaus County, California",
-    "geo.position": `${AMP_VENDING_BUSINESS_INFO.address.coordinates.latitude};${AMP_VENDING_BUSINESS_INFO.address.coordinates.longitude}`,
-    ICBM: `${AMP_VENDING_BUSINESS_INFO.address.coordinates.latitude}, ${AMP_VENDING_BUSINESS_INFO.address.coordinates.longitude}`,
+    // Geographic targeting - uses SEO_CONSTANTS.ADDRESS
+    "geo.region": `US-${SEO_CONSTANTS.ADDRESS.STATE}`,
+    "geo.placename": `${SEO_CONSTANTS.ADDRESS.CITY}, ${SEO_CONSTANTS.ADDRESS.COUNTY}, ${SEO_CONSTANTS.ADDRESS.STATE_FULL}`,
+    "geo.position": `${SEO_CONSTANTS.ADDRESS.COORDINATES.LAT};${SEO_CONSTANTS.ADDRESS.COORDINATES.LNG}`,
+    ICBM: `${SEO_CONSTANTS.ADDRESS.COORDINATES.LAT}, ${SEO_CONSTANTS.ADDRESS.COORDINATES.LNG}`,
 
     // Business information
-    coverage: "Modesto, Stanislaus County, Central California",
+    coverage: SEO_CONSTANTS.SERVICE_AREA,
     distribution: "global",
     rating: "general",
     "revisit-after": "7 days",
 
     // Contact information
-    contact: AMP_VENDING_BUSINESS_INFO.contact.email,
-    "reply-to": AMP_VENDING_BUSINESS_INFO.contact.email,
+    contact: SEO_CONSTANTS.EMAIL,
+    "reply-to": SEO_CONSTANTS.EMAIL,
 
     // Copyright and ownership
-    copyright: `© ${new Date().getFullYear()} ${AMP_VENDING_BUSINESS_INFO.name}. All rights reserved.`,
-    owner: AMP_VENDING_BUSINESS_INFO.name,
+    copyright: `© ${new Date().getFullYear()} ${SEO_CONSTANTS.BUSINESS_LEGAL_NAME}. All rights reserved.`,
+    owner: SEO_CONSTANTS.BUSINESS_NAME,
 
     // Mobile optimization
     "format-detection": "telephone=yes",
     "mobile-web-app-capable": "yes",
     "apple-mobile-web-app-capable": "yes",
     "apple-mobile-web-app-status-bar-style": "black-translucent",
-    "apple-mobile-web-app-title": AMP_VENDING_BUSINESS_INFO.name,
+    "apple-mobile-web-app-title": SEO_CONSTANTS.SITE_NAME,
 
     // Theme colors for browser integration
     "theme-color": "#000000",
@@ -232,7 +166,7 @@ export const rootMetadata: Metadata = {
   // Icons and manifest - optimized for Google Search Results
   icons: {
     icon: [
-      // SVG favicon - preferred by Google for search results (scalable, crisp at any size)
+      // SVG favicon - preferred by Google for search results
       { url: "/icon.svg", type: "image/svg+xml" },
       // PNG fallbacks for browsers that don't support SVG favicons
       { url: "/favicon-32x32.png", sizes: "32x32", type: "image/png" },
@@ -252,6 +186,6 @@ export const rootMetadata: Metadata = {
     ],
   },
 
-  // Web app manifest.webmanifest for PWA capabilities and enhanced mobile search presence
+  // Web app manifest for PWA capabilities
   manifest: "/manifest.webmanifest",
 };

--- a/lib/data/seoData.ts
+++ b/lib/data/seoData.ts
@@ -6,8 +6,8 @@ import { Metadata } from "next";
 export const SEO_CONSTANTS = {
   // Website Identity
   SITE_NAME: 'AMP Vending Machines',
-  SITE_TITLE: 'AMP Vending Machines | Modesto, Stockton, Stanislaus & San Joaquin County | Premium Commercial Vending',
-  SITE_DESCRIPTION: 'ampvendingmachines.com - Leading vending machine provider in Modesto, Stockton, Stanislaus County, San Joaquin County & Central California. Professional touchscreen vending machines with 50+ products. Free installation. Call (209) 403-5450',
+  SITE_TITLE: 'AMP Vending Machines | Modesto, Stockton, Stanislaus & San Joaquin County | Free Vending Machine Placement | Snack & Drink Machines | ',
+  SITE_DESCRIPTION: 'Get a free vending machine for your business. Snack, drink & combo vending machines with cashless payment, touchscreen technology. No cost installation in Modesto, Stockton, & Central Valley, CA. Call (209) 403-5450',
   
   // URLs and Domains
   BASE_URL: 'https://www.ampvendingmachines.com',
@@ -40,7 +40,7 @@ export const SEO_CONSTANTS = {
   },
   
   // Service Area
-  SERVICE_AREA: 'Modesto, Stockton, Stanislaus County, San Joaquin County & Central California',
+  SERVICE_AREA: 'Modesto, Stockton, Stanislaus County, San Joaquin County & Central Valley, CA',
   SERVICE_COUNTY: 'Stanislaus County, San Joaquin County',
   PRIMARY_CITIES: [
     // Stanislaus County (Top Priority)
@@ -66,7 +66,7 @@ export const SEO_CONSTANTS = {
     'Mountain House', 'French Camp', 'Country Club', 'Woodbridge', 'Lockeford'
   ],
   
-  // Industry Keywords
+  // Industry Keywords - Optimized for High Search Volume (2026)
   PRIMARY_KEYWORDS: [
     // Brand Keywords
     'ampvendingmachines',
@@ -74,6 +74,41 @@ export const SEO_CONSTANTS = {
     'amp vending machines',
     'amp vending',
     'ampvending',
+
+    // HIGH VOLUME: "Near Me" Keywords (Most Searched)
+    'vending machine near me',
+    'vending machines near me',
+    'vending machine company near me',
+    'vending services near me',
+    'vending machine service near me',
+    'snack machine near me',
+    'drink machine near me',
+
+    // HIGH VOLUME: Free Vending / Business Placement (High Intent)
+    'free vending machine placement',
+    'free vending machine for my business',
+    'get a free vending machine',
+    'no cost vending machine',
+    'free vending machine installation',
+    'free vending services',
+    'vending machine for my business',
+    'how to get a vending machine for my business',
+    'vending machine placement',
+    'put vending machine in my business',
+
+    // HIGH VOLUME: Business Location Types (High Intent)
+    'vending machine for office',
+    'vending machines for workplaces',
+    'vending machine for warehouse',
+    'vending machine for school',
+    'vending machine for hotel',
+    'vending machine for gym',
+    'vending machine for factory',
+    'vending machine for hospital',
+    'break room vending machine',
+    'employee vending solutions',
+    'corporate vending services',
+    'industrial vending machines',
 
     // Location + Service Keywords (Highest Priority)
     'vending machines Modesto',
@@ -111,10 +146,21 @@ export const SEO_CONSTANTS = {
     'vending machines Escalon CA',
 
     // Regional Terms
-    'Central California vending machines',
+    'Central Valley, CA vending machines',
     'Central Valley vending machines',
+    'Northern California vending machines',
     'vending machine supplier Stanislaus County',
     'vending machine supplier San Joaquin County',
+
+    // HIGH VOLUME: Machine Types (Product Keywords)
+    'snack vending machine',
+    'drink vending machine',
+    'beverage vending machine',
+    'combo vending machine',
+    'combination vending machine',
+    'healthy vending machine',
+    'cold drink vending machine',
+    'food vending machine',
 
     // Service Type Keywords
     'commercial vending machines',
@@ -124,12 +170,17 @@ export const SEO_CONSTANTS = {
     'company vending machines',
     'employee vending machines',
 
-    // Feature Keywords
+    // HIGH VOLUME: Payment/Technology Features
+    'cashless vending machines',
+    'credit card vending machines',
+    'tap to pay vending machine',
+    'card reader vending machine',
+    'apple pay vending machine',
+    'contactless payment vending machine',
     'touchscreen vending machines',
     'modern vending machines',
     'smart vending machines',
     'contactless vending machines',
-    'cashless vending machines',
     'refrigerated vending machines',
 
     // Service Keywords
@@ -138,17 +189,23 @@ export const SEO_CONSTANTS = {
     'vending machine vendor',
     'vending machine installation',
     'vending machine rental',
+    'vending machine leasing',
     'vending machine service',
     'vending machine maintenance',
+    'vending machine restocking',
     'free vending machines',
+    'full service vending',
+    'vending machine management',
 
     // Industry Terms
     'premium vending machines',
     'professional vending',
     'maintenance-free vending',
-    'full service vending',
     'custom vending solutions',
     'vending machines for businesses',
+    'vending solutions',
+    'automated retail',
+    'unattended retail',
   ],
 
   // Open Graph Image Defaults
@@ -186,44 +243,44 @@ export const PAGE_METADATA = {
       canonical: SEO_CONSTANTS.BASE_URL,
     },
     openGraph: {
-      title: 'AMP Vending Machines | Modesto, Stockton, Stanislaus & San Joaquin County Vending Solutions',
-      description: 'Leading vending machine provider in Modesto, Stockton, Stanislaus County, San Joaquin County & Central California. Premium touchscreen vending machines with free installation.',
+      title: 'AMP Vending Machines | Modesto, Stockton, Stanislaus & San Joaquin County Vending Solutions | Free Vending Machine Placement | Snack & Drink Machines for Your Business | Central Valley, CA',
+      description: 'Get a free vending machine for your office, warehouse, or workplace. Snack, drink & combo machines with cashless payment. No cost installation in Modesto, Stockton & Central Valley, California.',
       url: SEO_CONSTANTS.BASE_URL,
       siteName: SEO_CONSTANTS.SITE_NAME,
       images: [{
         url: SEO_CONSTANTS.DEFAULT_OG_IMAGE_FULL,
         width: SEO_CONSTANTS.OG_IMAGE_WIDTH,
         height: SEO_CONSTANTS.OG_IMAGE_HEIGHT,
-        alt: 'AMP Vending premium workplace vending machines',
+        alt: 'Free vending machine placement - snack and drink machines for businesses',
       }],
       locale: 'en_US',
       type: 'website',
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'AMP Vending Machines | Modesto, Stockton, Stanislaus & San Joaquin County',
-      description: 'ampvendingmachines.com - Premium vending machine provider in Modesto, Stockton, Stanislaus County, San Joaquin County & Central California with touchscreen technology.',
+      title: 'AMP Vending Machines | Modesto, Stockton, Stanislaus & San Joaquin County Vending Solutions | Free Vending Machine Placement | Snack & Drink Machines for Your Business | Central Valley, CA',
+      description: 'Get a free vending machine for your office, warehouse, or workplace. Snack, drink & combo machines with cashless payment. No cost installation in Modesto, Stockton & Central Valley, California.',
       images: [SEO_CONSTANTS.DEFAULT_OG_IMAGE_FULL],
     },
   } satisfies Metadata,
 
   VENDING_MACHINES: {
-    title: 'Vending Machines Modesto, Stockton | Stanislaus & San Joaquin County | Commercial & Office Solutions',
-    description: 'ampvendingmachines.com offers premium commercial vending machines in Modesto, Stockton, Stanislaus County, San Joaquin County & Central California. Free installation, 21.5" touchscreen, 50+ products. Call (209) 403-5450',
-    keywords: 'vending machines Modesto, vending machines Stockton, vending machines Stanislaus County, vending machines San Joaquin County, Modesto vending machines, Stockton vending machines, ampvendingmachines, commercial vending machines, office vending machines Modesto CA, office vending machines Stockton CA, touchscreen vending, workplace vending solutions',
+    title: 'Snack & Drink Vending Machines | Free Placement for Offices & Businesses |  Modesto, Stockton | Stanislaus & San Joaquin County | Central Valley, CA',
+    description: 'Browse our snack, drink & combo vending machines. Free vending machine placement for offices, warehouses & workplaces in Modesto, Stockton & Central CA. Cashless payment, touchscreen. Call (209) 403-5450',
+    keywords: 'snack vending machine, drink vending machine, combo vending machine, beverage vending machine, free vending machine placement, vending machine for office, vending machine for warehouse, cashless vending machines, credit card vending machine, vending machines Modesto, vending machines Stockton, Stanislaus County, San Joaquin County & Central Valley, California.  commercial vending machines, office vending machines, workplace vending solutions, break room vending machine',
     alternates: {
       canonical: `${SEO_CONSTANTS.BASE_URL}/vending-machines`,
     },
     openGraph: {
-      title: 'Premium Vending Machines | AMP Vending',
-      description: 'Professional vending Machines with touchscreen technology and 50+ customizable product options.',
+      title: 'Free Snack & Drink Vending Machines for Your Business | AMP Vending',
+      description: 'Snack, drink & combo vending machines with cashless payment. Free placement for offices, warehouses & workplaces. No cost installation & maintenance.',
       url: `${SEO_CONSTANTS.BASE_URL}/vending-machines`,
       siteName: SEO_CONSTANTS.SITE_NAME,
       images: [{
         url: `${SEO_CONSTANTS.BASE_URL}/images/og/amp-vending-logo-og.webp`,
         width: SEO_CONSTANTS.OG_IMAGE_WIDTH,
         height: SEO_CONSTANTS.OG_IMAGE_HEIGHT,
-        alt: 'AMP Premium Vending Machines Collection',
+        alt: 'Snack and drink vending machines - free placement for businesses',
       }],
       locale: 'en_US',
       type: 'website',
@@ -233,15 +290,15 @@ export const PAGE_METADATA = {
 
   
 // ABOUT: {
-//   title: 'About AMP Vending | Professional Vending Machines in Central California',
-//   description: 'Learn about AMP Vending\'s commitment to providing premium workplace vending Machines. Serving Central California with professional installation, maintenance, and 24/7 support.',
-//   keywords: 'about AMP Vending, vending machine company, Central California vending, professional vending services, workplace Machines, Modesto vending, Andrew Perez founder',
+//   title: 'About AMP Vending | Professional Vending Machines in Central Valley, CA',
+//   description: 'Learn about AMP Vending\'s commitment to providing premium workplace vending Machines. Serving Central Valley, CA with professional installation, maintenance, and 24/7 support.',
+//   keywords: 'about AMP Vending, vending machine company, Central Valley, CA vending, professional vending services, workplace Machines, Modesto vending, Andrew Perez founder',
 //   alternates: {
 //     canonical: `${SEO_CONSTANTS.BASE_URL}/about`,
 //   },
 //   openGraph: {
 //     title: 'About AMP Vending - Your Trusted Vending Partner',
-//     description: 'Professional vending Machines with a commitment to excellence. Serving workplaces across Central California with premium machines and comprehensive service.',
+//     description: 'Professional vending Machines with a commitment to excellence. Serving workplaces across Central Valley, CA with premium machines and comprehensive service.',
 //     url: `${SEO_CONSTANTS.BASE_URL}/about`,
 //     siteName: SEO_CONSTANTS.SITE_NAME,
 //     images: [{
@@ -256,28 +313,28 @@ export const PAGE_METADATA = {
 //   twitter: {
 //     card: 'summary_large_image',
 //     title: 'About AMP Vending - Professional Vending Machines',
-//     description: 'Learn about our commitment to excellence in workplace vending Machines across Central California.',
+//     description: 'Learn about our commitment to excellence in workplace vending Machines across Central Valley, CA.',
 //     images: [`${SEO_CONSTANTS.BASE_URL}/images/about/amp-vending-about.jpg`],
 //   },
 // } satisfies Metadata,
 
   CONTACT: {
-    title: 'Contact AMP Vending Machines | Modesto, Stockton, Stanislaus & San Joaquin County | (209) 403-5450',
-    description: 'Contact ampvendingmachines.com for free vending machine consultation in Modesto, Stockton, Stanislaus County, San Joaquin County & Central California. Professional installation & service. Call (209) 403-5450 today!',
-    keywords: 'contact AMP vending machines, vending machines Modesto, vending machines Stockton, Modesto vending company, Stockton vending company, Stanislaus County vending, San Joaquin County vending, ampvendingmachines contact, vending machine consultation',
+    title: 'Get a Free Vending Machine for Your Business | Contact AMP Vending | Modesto, Stockton, Stanislaus & San Joaquin County | (209) 403-5450',
+    description: 'Request a free vending machine placement for your office, warehouse, or workplace. No cost installation. Snack & drink machines with cashless payment. Serving Modesto, Stockton & Central Valley, CA. Call (209) 403-5450',
+    keywords: 'get a free vending machine, free vending machine placement, vending machine for my business, vending machine consultation, contact vending company, vending machines near me, vending machine supplier, office vending machine, workplace vending machine, Modesto vending, Stockton vending',
     alternates: {
       canonical: `${SEO_CONSTANTS.BASE_URL}/contact`,
     },
     openGraph: {
-      title: 'Contact AMP Vending - Professional Consultation',
-      description: 'Get in touch for professional vending machine consultation and premium workplace Machines.',
+      title: 'Get a Free Vending Machine for Your Business | AMP Vending',
+      description: 'Request free vending machine placement for your office, warehouse, or workplace. No cost installation & maintenance. Serving Central Valley,  California.',
       url: `${SEO_CONSTANTS.BASE_URL}/contact`,
       siteName: SEO_CONSTANTS.SITE_NAME,
       images: [{
         url: `${SEO_CONSTANTS.BASE_URL}/images/og/contact.jpg`,
         width: SEO_CONSTANTS.OG_IMAGE_WIDTH,
         height: SEO_CONSTANTS.OG_IMAGE_HEIGHT,
-        alt: 'Contact AMP Vending for workplace Machines',
+        alt: 'Get a free vending machine for your business',
       }],
       locale: 'en_US',
       type: 'website',
@@ -416,7 +473,7 @@ export const BASE_ORGANIZATION_SCHEMA = {
   url: SEO_CONSTANTS.BASE_URL,
   logo: SEO_CONSTANTS.LOGO_FULL_URL,
   image: SEO_CONSTANTS.DEFAULT_OG_IMAGE_FULL,
-  description: 'ampvendingmachines.com - Premier vending machine provider serving Modesto, Stockton, Stanislaus County, San Joaquin County & Central California with professional touchscreen vending solutions.',
+  description: 'ampvendingmachines.com - Premier vending machine provider serving Modesto, Stockton, Stanislaus County, San Joaquin County & Central Valley, CA with professional touchscreen vending solutions.',
   telephone: SEO_CONSTANTS.PHONE,
   email: SEO_CONSTANTS.EMAIL,
   priceRange: 'Free installation and maintenance',
@@ -528,7 +585,7 @@ export function generateAboutPageStructuredData() {
     '@context': 'https://schema.org',
     '@type': 'AboutPage',
     name: 'About AMP Vending',
-    description: 'Learn about AMP Vending\'s commitment to providing premium workplace vending Machines in Central California.',
+    description: 'Learn about AMP Vending\'s commitment to providing premium workplace vending Machines in Central Valley, CA.',
     url: `${SEO_CONSTANTS.BASE_URL}/about`,
     mainEntityOfPage: {
       '@type': 'WebPage',
@@ -539,8 +596,8 @@ export function generateAboutPageStructuredData() {
       '@id': `${SEO_CONSTANTS.BASE_URL}/#organization`,
       name: SEO_CONSTANTS.BUSINESS_NAME,
       legalName: SEO_CONSTANTS.BUSINESS_LEGAL_NAME,
-      description: 'Professional vending machine Machines for workplaces across Central California',
-      foundingDate: '2019',
+      description: 'Professional vending machine Machines for workplaces across Central Valley, CA',
+      foundingDate: '2025',
       founders: [
         {
           '@type': 'Person',


### PR DESCRIPTION
Replaced manual pathname handling with Next.js's usePathname() hook which automatically updates during client-side navigation:

// Before (broken)
const [pathname, setPathname] = useState<string>(''); useEffect(() => {
  setPathname(window.location.pathname);
}, []); // Only runs once on mount!

// After (fixed)
import { usePathname } from 'next/navigation';
const pathname = usePathname(); // Reactively updates on navigation Changes in ResizableNavbar.tsx
Added import { usePathname } from 'next/navigation' Replaced useState + useEffect pattern with usePathname() hook Removed unused isMounted state variable
The active page highlight will now correctly update when navigating between pages.