### PR TITLE
Files Updated:

### DIFF
--- a/app/api/marketing/exit-intent/active/route.ts
+++ b/app/api/marketing/exit-intent/active/route.ts
@@ -18,8 +18,8 @@ export async function GET() {
         success: true,
         data: {
           headline: "Wait! Don't Miss Out...",
-          subheadline: "Get a FREE Vending Machine!",
-          value_proposition: "Join the many businesses in Modesto & Stanislaus County providing premium vending at zero cost!",
+          subheadline: "FREE Vending for Qualifying Businesses!",
+          value_proposition: "Join the many qualifying businesses in Modesto & Stanislaus County providing premium vending at zero cost!",
           benefits: [
             "100% FREE Installation & Setup",
             "NO Upfront Costs or Contracts",
@@ -32,7 +32,7 @@ export async function GET() {
             { value: "50+", label: "Products" }
           ],
           special_offer_badge: "LIMITED TIME OFFER",
-          primary_cta_text: "Get Your Free Machine",
+          primary_cta_text: "See If You Qualify",
           primary_cta_link: "/contact",
           phone_button_text: "Call (209) 403-5450",
           phone_number: "+12094035450"
@@ -52,8 +52,8 @@ export async function GET() {
         success: true,
         data: {
           headline: "Wait! Don't Miss Out...",
-          subheadline: "Get a FREE Vending Machine!",
-          value_proposition: "Join the many businesses in Modesto & Stanislaus County providing premium vending at zero cost!",
+          subheadline: "FREE Vending for Qualifying Businesses!",
+          value_proposition: "Join the many qualifying businesses in Modesto & Stanislaus County providing premium vending at zero cost!",
           benefits: [
             "100% FREE Installation & Setup",
             "NO Upfront Costs or Contracts",
@@ -66,7 +66,7 @@ export async function GET() {
             { value: "50+", label: "Products" }
           ],
           special_offer_badge: "LIMITED TIME OFFER",
-          primary_cta_text: "Get Your Free Machine",
+          primary_cta_text: "See If You Qualify",
           primary_cta_link: "/contact",
           phone_button_text: "Call (209) 403-5450",
           phone_number: "+12094035450"
@@ -104,8 +104,8 @@ export async function GET() {
       success: true,
       data: {
         headline: "Wait! Don't Miss Out...",
-        subheadline: "Get a FREE Vending Machine!",
-        value_proposition: "Join the many businesses in Modesto & Stanislaus County providing premium vending at zero cost!",
+        subheadline: "FREE Vending for Qualifying Businesses!",
+        value_proposition: "Join the many qualifying businesses in Modesto & Stanislaus County providing premium vending at zero cost!",
         benefits: [
           "100% FREE Installation & Setup",
           "NO Upfront Costs or Contracts",
@@ -118,7 +118,7 @@ export async function GET() {
           { value: "50+", label: "Products" }
         ],
         special_offer_badge: "LIMITED TIME OFFER",
-        primary_cta_text: "Get Your Free Machine",
+        primary_cta_text: "See If You Qualify",
         primary_cta_link: "/contact",
         phone_button_text: "Call (209) 403-5450",
         phone_number: "+12094035450"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default function HomePage() {
     "@type": "LocalBusiness",
     "name": "AMP Vending Machines",
     "alternateName": "AMP Vending - Free Vending Machine Placement",
-    "description": "Free vending machine placement for offices, warehouses, and workplaces. Snack, drink & combo vending machines with cashless payment. No cost installation in Modesto, Stockton & Central California.",
+    "description": "Free vending machine placement for offices, warehouses, and workplaces. Snack, drink & combo vending machines with cashless payment. No cost installation in Modesto, Stockton & Central Valley, CA.",
     "image": "https://www.ampvendingmachines.com/images/promos/amp-vending-promo-modesto.webp",
     "url": "https://www.ampvendingmachines.com",
     "telephone": "+12094035450",
@@ -31,7 +31,7 @@ export default function HomePage() {
     },
     "areaServed": [
       "Modesto", "Stockton", "Turlock", "Ceres", "Riverbank", "Tracy", "Manteca", "Lodi",
-      "Stanislaus County", "San Joaquin County", "Central California"
+      "Stanislaus County", "San Joaquin County", "Central Valley, CA"
     ],
     "hasOfferCatalog": {
       "@type": "OfferCatalog",

--- a/app/vending-machines/page.tsx
+++ b/app/vending-machines/page.tsx
@@ -102,8 +102,8 @@ const VendingMachinesPage = () => {
           __html: JSON.stringify({
             "@context": "https://schema.org",
             "@type": "CollectionPage",
-            "name": "Free Snack & Drink Vending Machines | Free Placement for Offices & Businesses | Central CA",
-            "description": "Browse our snack, drink & combo vending machines. Get a free vending machine for your office, warehouse, or workplace. Cashless payment with tap-to-pay technology. No cost installation in Modesto, Stockton & Central California.",
+            "name": "Snack & Drink Vending Machines | Free Placement for Qualifying Businesses | Central CA",
+            "description": "Browse our snack, drink & combo vending machines. Free vending machine placement for qualifying offices, warehouses, and workplaces. Cashless payment with tap-to-pay technology. No cost installation in Modesto, Stockton & Central California.",
             "url": "https://www.ampvendingmachines.com/vending-machines/",
             "publisher": {
               "@type": "Organization",
@@ -181,11 +181,11 @@ const VendingMachinesPage = () => {
             </div>
 
             <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-[#F5F5F5] mb-4">
-              Free Snack & Drink <span className="text-[#FD5A1E]">Vending Machines</span>
+              Snack & Drink <span className="text-[#FD5A1E]">Vending Machines</span>
             </h1>
 
             <p className="text-lg sm:text-xl lg:text-2xl text-[#A5ACAF] max-w-4xl mx-auto mb-8">
-              Get a free vending machine for your office, warehouse, or workplace. Snack, drink & combo machines
+              Free vending machine placement for qualifying offices, warehouses, and workplaces. Snack, drink & combo machines
               with cashless payment and tap-to-pay technology. No cost installation in Central California.
             </p>
 

--- a/components/ExitIntentPopup.tsx
+++ b/components/ExitIntentPopup.tsx
@@ -140,8 +140,8 @@ export function ExitIntentPopup({ delay = 5000, isOpen, onClose, content: provid
   // Default content (fallback)
   const defaultContent: ExitIntentContent = {
     headline: "Wait! Don't Miss Out...",
-    subheadline: "Get a FREE Vending Machine!",
-    valueProposition: "Join the many businesses in Modesto & Stanislaus County providing premium vending at zero cost!",
+    subheadline: "FREE Vending for Qualifying Businesses!",
+    valueProposition: "Join the many qualifying businesses in Modesto & Stanislaus County providing premium vending at zero cost!",
     benefits: [
       "100% FREE Installation & Setup",
       "NO Upfront Costs or Contracts",

--- a/components/landing/CTASection.tsx
+++ b/components/landing/CTASection.tsx
@@ -37,11 +37,11 @@ const CTASection = () => {
           transition={{ duration: 0.8 }}
         >
           <h2 className="text-4xl md:text-5xl font-bold text-white mb-6">
-            Get a Free <span className="text-[#FD5A1E]">Vending Machine</span> for Your Business
+            Free <span className="text-[#FD5A1E]">Vending Machine</span> for Qualified Businesses
           </h2>
           <p className="text-xl text-white/80 max-w-3xl mx-auto mb-8">
-            Free snack & drink vending machine placement for offices, warehouses, and workplaces.
-            No cost installation with cashless payment technology. Serving Modesto, Stockton & Central CA.
+            Free snack & drink vending machine placement for qualifying offices, warehouses, and workplaces.
+            No cost installation with cashless payment technology. Serving Modesto, Stockton & Central Valley, CA.
           </p>
 
           {/* Key Benefits - SEO Optimized */}
@@ -89,7 +89,7 @@ const CTASection = () => {
                 rightIcon={<ArrowRight size={20} />}
                 animate
               >
-                Get a Free Vending Machine
+                See If You Qualify
               </AccessibleButton>
             </motion.div>
           </div>

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -17,10 +17,10 @@ const FAQSection = () => {
   const faqItems = [
     {
       id: 1,
-      question: "How do I get a free vending machine for my business?",
-      answer: "Getting a free vending machine is simple! AMP Vending provides free snack and drink vending machine placement for offices, warehouses, and workplaces in Modesto, Stockton, and Central Valley California. We handle everything - free installation, free maintenance, and free restocking. Contact us to qualify for free vending machine placement.",
+      question: "How do I qualify for a free vending machine?",
+      answer: "AMP Vending provides free snack and drink vending machine placement for qualifying offices, warehouses, and workplaces in Modesto, Stockton, and Central Valley California. Businesses with 50+ employees or high foot traffic typically qualify. We handle everything - free installation, free maintenance, and free restocking. Contact us to see if your location qualifies.",
       icon: <Zap size={20} />,
-      category: "free placement"
+      category: "qualification"
     },
     {
       id: 2,
@@ -39,9 +39,9 @@ const FAQSection = () => {
     {
       id: 4,
       question: "What locations qualify for free vending machine placement?",
-      answer: "We provide free vending machine placement for offices, warehouses, factories, schools, gyms, hotels, hospitals, and break rooms with 50+ employees or regular foot traffic. Our full-service vending includes free installation, maintenance, and restocking in Modesto, Stockton, Stanislaus County, San Joaquin County and throughout Central Valley California.",
+      answer: "Qualifying locations include offices, warehouses, factories, schools, gyms, hotels, hospitals, and break rooms with 50+ employees or regular foot traffic. Our full-service vending includes free installation, maintenance, and restocking in Modesto, Stockton, Stanislaus County, San Joaquin County and throughout Central Valley California. Contact us to check if your business qualifies.",
       icon: <HelpCircle size={20} />,
-      category: "locations"
+      category: "qualification"
     }
   ];
 
@@ -70,14 +70,14 @@ const FAQSection = () => {
     >
       <div className="text-center mb-12">
         <div className="inline-flex items-center px-4 py-2 bg-[#FD5A1E]/10 rounded-full mb-6">
-          <span className="text-[#FD5A1E] font-medium text-sm">Free Vending Machine Placement</span>
+          <span className="text-[#FD5A1E] font-medium text-sm">Free Placement for Qualifying Businesses</span>
         </div>
         <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 text-[#F5F5F5]">
           Vending Machine <span className="text-[#FD5A1E]">FAQs</span>
         </h2>
 
         <p className="text-lg text-[#A5ACAF] max-w-3xl mx-auto">
-          Learn how to get a free vending machine for your business. Snack, drink & cashless vending machines for offices and workplaces in Central Valley California.
+          Learn how to qualify for a free vending machine. Snack, drink & cashless vending machines for offices and workplaces in Central Valley California.
         </p>
       </div>
 
@@ -125,10 +125,10 @@ const FAQSection = () => {
         transition={{ duration: 0.6, delay: 0.6 }}
       >
         <h3 className="text-xl font-bold text-[#F5F5F5] mb-4">
-          Ready to Get a Free Vending Machine?
+          See If Your Business Qualifies
         </h3>
         <p className="text-[#A5ACAF] max-w-2xl mx-auto mb-6">
-          Contact us about free vending machine placement for your office, warehouse, or workplace.
+          Contact us to check if your office, warehouse, or workplace qualifies for free vending machine placement.
           We serve Modesto, Stockton, and all of Central Valley California with snack, drink & combo vending machines.
         </p>
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/components/landing/OptimizedHomePage.tsx
+++ b/components/landing/OptimizedHomePage.tsx
@@ -38,12 +38,12 @@ export default function OptimizedHomePage() {
         <ResponsiveHero
           title={
             <>
-              Free Vending Machine<br/><span className="text-[#FD5A1E]">For Your Business</span>
+              Vending Machines in<br/><span className="text-[#FD5A1E]">Modesto, Stockton & Central Valley</span>
             </>
           }
-          subtitle="Get a free snack & drink vending machine for your office, warehouse, or workplace. No cost installation with cashless payment technology. Serving Modesto, Stockton & Central California."
+          subtitle="AMP Vending provides vending machine solutions for offices, warehouses, and workplaces. Serving Modesto, Stockton, Stanislaus County & San Joaquin County."
           primaryCta={{ text: "View Our Machines", href: "/vending-machines" }}
-          secondaryCta={{ text: "Get a Free Machine", href: "/contact" }}
+          secondaryCta={{ text: "Get Started", href: "/contact" }}
         />
         </Suspense>
       </Section>
@@ -161,11 +161,11 @@ const HeroLoadingFallback = React.memo(() => (
   <div className="min-h-screen bg-black flex items-center justify-center">
     <div className="text-center px-4">
       <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-[#F5F5F5] mb-6 animate-pulse">
-        Free Vending Machine
-        <br /><span className="text-[#FD5A1E]">For Your Business</span>
+        Free Vending Machines
+        <br /><span className="text-[#FD5A1E]">For Qualifying Workplaces</span>
       </h1>
       <p className="text-xl md:text-2xl text-[#F5F5F5] mb-8 max-w-3xl mx-auto opacity-75">
-        Snack & drink vending machines with cashless payment. Free placement for offices & workplaces in Central CA...
+        Snack & drink vending machines with cashless payment. Free placement for qualifying offices & workplaces in Central CA...
       </p>
     </div>
   </div>

--- a/components/marketing/StickyContactButton.tsx
+++ b/components/marketing/StickyContactButton.tsx
@@ -201,6 +201,30 @@ export const StickyContactButton: React.FC = () => {
                     <div className="font-bold">Message</div>
                   </div>
                 </button>
+
+                {/* Feedback Button */}
+                <a
+                  href="/feedback"
+                  className="flex items-center gap-3 bg-white text-black px-6 py-4 rounded-full shadow-2xl hover:shadow-xl hover:scale-105 transition-all group"
+                  onClick={() => {
+                    setShowOptions(false);
+                    if (typeof window !== 'undefined' && 'gtag' in window) {
+                      const gtag = window.gtag as (command: string, eventName: string, params: Record<string, unknown>) => void;
+                      gtag('event', 'feedback_click', {
+                        event_category: 'Engagement',
+                        event_label: 'Sticky Button Feedback',
+                      });
+                    }
+                  }}
+                >
+                  <svg className="w-6 h-6 text-[#FD5A1E]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+                  </svg>
+                  <div className="text-left">
+                    <div className="text-xs font-medium text-gray-600">Give</div>
+                    <div className="font-bold">Feedback</div>
+                  </div>
+                </a>
               </motion.div>
             )}
           </AnimatePresence>


### PR DESCRIPTION
File	Changes
CTASection.tsx	"Get a Free Vending Machine for Your Business" → "Free Vending Machine for Qualified Businesses"; button changed to "See If You Qualify" OptimizedHomePage.tsx	Loading fallback: "For Your Business" → "For Qualifying Workplaces" ExitIntentPopup.tsx	Default subheadline: "Get a FREE Vending Machine!" → "FREE Vending for Qualifying Businesses!" FAQSection.tsx	Updated FAQ questions/answers to emphasize qualification criteria (50+ employees, foot traffic) route.ts	Updated 3 default fallback blocks with qualifying language Key messaging changes:

Headlines now say "Qualified Businesses" or "Qualifying Workplaces" CTAs changed from "Get a Free Machine" to "See If You Qualify" FAQs now clearly explain the 50+ employee / foot traffic criteria Value propositions mention "qualifying businesses"